### PR TITLE
Allow setting the output stream

### DIFF
--- a/src/main/java/me/tongfei/progressbar/ProgressBar.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBar.java
@@ -20,7 +20,7 @@ public class ProgressBar {
     private LocalDateTime startTime = null;
     private LocalDateTime lastTime = null;
     private String extraMessage = "";
-    private PrintStream consoleStream = System.out;
+    private PrintStream consoleStream = OutputStream.OUT.stream;
     final private Object syncRoot = new Object();
 
     /**
@@ -178,9 +178,25 @@ public class ProgressBar {
 
     /**
      * Sets the stream to which the progress bar will be printed.
-     * @param stream Output stream
+     * @param outputStream Output stream
      */
-    public void setStream(PrintStream stream) {
-        consoleStream = stream;
+    public void setOutputStream(OutputStream outputStream) {
+        consoleStream = outputStream.stream;
+    }
+
+    /**
+     * Streams the progress bar can be written to.
+     */
+    public enum OutputStream {
+        /** The standard output stream, System.out. */
+        OUT(System.out),
+        /** The standard error stream, System.err. */
+        ERR(System.err);
+
+        private PrintStream stream;
+
+        private OutputStream(PrintStream stream) {
+            this.stream = stream;
+        }
     }
 }

--- a/src/main/java/me/tongfei/progressbar/ProgressBar.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBar.java
@@ -1,5 +1,6 @@
 package me.tongfei.progressbar;
 
+import java.io.PrintStream;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import jline.TerminalFactory;
@@ -19,6 +20,7 @@ public class ProgressBar {
     private LocalDateTime startTime = null;
     private LocalDateTime lastTime = null;
     private String extraMessage = "";
+    private PrintStream consoleStream = System.out;
     final private Object syncRoot = new Object();
 
     /**
@@ -86,7 +88,7 @@ public class ProgressBar {
     }
 
     private void forceShow(LocalDateTime currentTime) {
-        System.out.print('\r');
+        consoleStream.print('\r');
         Duration elapsed = Duration.between(startTime, currentTime);
         lastTime = currentTime;
 
@@ -97,7 +99,7 @@ public class ProgressBar {
 
         String message = prefix + repeat('=', progress()) + repeat(' ', length - progress()) + suffix;
         int lastMessageLength = message.length();
-        System.out.print(message + repeat(' ', lastMessageLength - message.length()));
+        consoleStream.print(message + repeat(' ', lastMessageLength - message.length()));
     }
 
     private void show() {
@@ -162,7 +164,7 @@ public class ProgressBar {
      */
     public void stop() {
         forceShow(LocalDateTime.now());
-        System.out.println();
+        consoleStream.println();
     }
 
     /**
@@ -172,5 +174,13 @@ public class ProgressBar {
     public void setExtraMessage(String newExtraMessage) {
         length = length + extraMessage.length() - newExtraMessage.length();
         extraMessage = newExtraMessage;
+    }
+
+    /**
+     * Sets the stream to which the progress bar will be printed.
+     * @param stream Output stream
+     */
+    public void setStream(PrintStream stream) {
+        consoleStream = stream;
     }
 }

--- a/src/main/java/me/tongfei/progressbar/ProgressBar.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBar.java
@@ -165,6 +165,7 @@ public class ProgressBar {
     public void stop() {
         forceShow(LocalDateTime.now());
         consoleStream.println();
+        startTime = null;
     }
 
     /**
@@ -181,6 +182,9 @@ public class ProgressBar {
      * @param outputStream Output stream
      */
     public void setOutputStream(OutputStream outputStream) {
+        if (startTime != null) {
+            throw new IllegalStateException("Cannot change output stream for an active progress bar");
+        }
         consoleStream = outputStream.stream;
     }
 

--- a/src/test/java/me/tongfei/progressbar/ProgressBarTest.java
+++ b/src/test/java/me/tongfei/progressbar/ProgressBarTest.java
@@ -26,6 +26,10 @@ public class ProgressBarTest {
                 pb.stepTo(8000);
             }
         }
+        try {
+            pb.setOutputStream(ProgressBar.OutputStream.ERR);
+            throw new AssertionError("Setting the output stream didn't throw!");
+        } catch (IllegalStateException ex) {}
         pb.stop();
     }
 


### PR DESCRIPTION
Because I usually write progress bars to `System.err`, and maybe there are other use cases for this.

Would you prefer it to be a constructor parameter? I don't think it's advisable to change the stream while the progress bar is shown.