### PR TITLE
Fixed #28 - Build produces WARNINGs about encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,11 @@
     <description>A console-based progress bar for JVM</description>
     <url>http://github.com/ctongfei/progressbar</url>
 
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
     <licenses>
         <license>
             <name>MIT</name>
@@ -64,10 +69,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
 o Cleaned up to use build encoding
 o Moved configuration into properties.