### PR TITLE
Fix link to CHANGELOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ try (ProgressBar pb = new ProgressBar("Test", 100)) { // name, initial max
 ```
 
 #### Changelog
-[CHANGELOG](https://github.com/ctongfei/progressbar/blob/master/CHANGELOG.md)
+[CHANGELOG](https://github.com/ctongfei/progressbar/blob/master/docs/changelog.md)


### PR DESCRIPTION
[keep a changelog](https://keepachangelog.com) really recommends to have a `CHANGELOG.md` file in the root of the repository. This is very common and helps open source people finding the information in new repositories easily.

I agree that it is important to have it nicely rendered at http://ctongfei.github.io/progressbar/changelog/.

In commit fdf2baac063a499b4f03b2a5af9d611c6890de41, the changelog was moved to `docs/` and renamed to `changelog.md`. This PR fixes the link.

I would recommend to revert the move. And then either 

1. maintain the file twice (`CHANGELOG.md` and `docs/changelog.md`)
2. Create a script copying the `CHANGELOG.md` to `docs/changelog.md` during some `gh-pages` deployment step. This is possible by using CircleCI and some magic shell script. See https://github.com/latextemplates/LNCS/blob/d44efccf2a3b6623733311b5b2860589bc175cc4/.circleci/config.yml#L26 for a quick example.