### PR TITLE
Add compatibility with jline that is used in kotlin-compiler

### DIFF
--- a/src/main/java/me/tongfei/progressbar/ProgressThread.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressThread.java
@@ -53,9 +53,23 @@ class ProgressThread implements Runnable {
             // Issue #42
             // Defaulting to a dumb terminal when a supported terminal can not be correctly created
             // see https://github.com/jline/jline3/issues/291
-            this.terminal = TerminalBuilder.builder().dumb(true).build();
+            String prop = System.getProperty("org.jline.terminal.dumb");
+            System.setProperty("org.jline.terminal.dumb", "true");
+            this.terminal = TerminalBuilder.builder().build();
+            if (prop == null) {
+                System.clearProperty("org.jline.terminal.dumb");
+            } else {
+                System.setProperty("org.jline.terminal.dumb", prop);
+            }
+        } catch (IOException ignored) {
         }
-        catch (IOException ignored) { }
+
+        try {
+            if (terminal.getSize().getColumns() >= 10)  // Workaround for issue #23 under IntelliJ
+                consoleWidth = terminal.getSize().getColumns();
+        } catch (NullPointerException e) {
+            // skip it
+        }
 
         if (terminal.getWidth() >= 10)  // Workaround for issue #23 under IntelliJ
             consoleWidth = terminal.getWidth();

--- a/src/main/java/me/tongfei/progressbar/ProgressThread.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressThread.java
@@ -70,9 +70,6 @@ class ProgressThread implements Runnable {
         } catch (NullPointerException e) {
             // skip it
         }
-
-        if (terminal.getWidth() >= 10)  // Workaround for issue #23 under IntelliJ
-            consoleWidth = terminal.getWidth();
     }
 
     // between 0 and 1


### PR DESCRIPTION
If there is kotlin-compiler is in the classpath ```Terminal``` cannot be built, because kotlin use old jline version and some methods are not supported. 

In changes, I add compatibility to jline lib that is used in kotlin-compiler.