### PR TITLE
Fix Slow Exit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.tongfei</groupId>
     <artifactId>progressbar</artifactId>
-    <version>0.7.4</version>
+    <version>0.7.3</version>
     <name>progressbar</name>
     <description>A console-based progress bar for JVM</description>
     <url>http://github.com/ctongfei/progressbar</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.tongfei</groupId>
     <artifactId>progressbar</artifactId>
-    <version>0.7.3</version>
+    <version>0.7.4</version>
     <name>progressbar</name>
     <description>A console-based progress bar for JVM</description>
     <url>http://github.com/ctongfei/progressbar</url>

--- a/src/main/java/me/tongfei/progressbar/ProgressBar.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBar.java
@@ -165,7 +165,7 @@ public class ProgressBar implements AutoCloseable {
      */
     @Override
     public void close() {
-        target.kill();
+        thread.interrupt();
         try {
             thread.join();
             target.consoleStream.print("\n");

--- a/src/main/java/me/tongfei/progressbar/ProgressThread.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressThread.java
@@ -44,7 +44,6 @@ class ProgressThread implements Runnable {
         this.style = style;
         this.updateInterval = updateInterval;
         this.consoleStream = consoleStream;
-        this.killed = false;
         this.unitName = unitName;
         this.unitSize = unitSize;
         this.isSpeedShown = isSpeedShown;
@@ -150,13 +149,9 @@ class ProgressThread implements Runnable {
         consoleStream.print(line);
     }
 
-    void kill() {
-    	killed = true;
-    }
-
     public void run() {
         try {
-            while (!killed) {
+            while (!Thread.interrupted()) {
                 refresh();
                 Thread.sleep(updateInterval);
             }

--- a/src/test/java/me/tongfei/progressbar/Issue50Test.java
+++ b/src/test/java/me/tongfei/progressbar/Issue50Test.java
@@ -1,0 +1,19 @@
+package me.tongfei.progressbar;
+
+import org.junit.Test;
+
+public class Issue50Test {
+    @Test
+    public void testCloseSpeed() throws Exception {
+        int tenSecondsInMS = 10 * 1000;
+        long startTime = System.currentTimeMillis();
+
+        try(ProgressBar pb = new ProgressBar("Foo", 100, tenSecondsInMS)){
+            Thread.sleep(5);
+        }
+
+        long endTime = System.currentTimeMillis();
+
+        assert((endTime - startTime) < tenSecondsInMS);
+    }
+}


### PR DESCRIPTION
At present progressbar version `0.7.3` will take on average `updateInterval / 2` milliseconds to terminate, and for very short runs, will take a minimum of `updateInterval` to complete its `close()` handler.

This patch fixes that by explicitly interrupting the `ProgressThread` as opposed to waiting for an internal semaphore to cleanup on the inner loop.  