### PR TITLE
Fix StringIndexOutOfBoundsException in DefaultProgressBarRenderer

### DIFF
--- a/src/main/java/me/tongfei/progressbar/DefaultProgressBarRenderer.java
+++ b/src/main/java/me/tongfei/progressbar/DefaultProgressBarRenderer.java
@@ -76,7 +76,7 @@ public class DefaultProgressBarRenderer implements ProgressBarRenderer {
         Duration elapsed = Duration.between(progress.startTime, currTime);
 
         String prefix = progress.task + " " + percentage(progress) + " " + style.leftBracket;
-        int maxSuffixLength = maxLength - prefix.length();
+        int maxSuffixLength = Math.max(maxLength - prefix.length(), 0);
 
         String speedString = isSpeedShown ? speed(progress, elapsed) : "";
         String suffix = style.rightBracket + " " + ratio(progress) + " ("


### PR DESCRIPTION
When `maxSuffixLength` is calculated the value could have been negative. To avoid this we wrap it in a max function, with lower bound of 0.