### PR TITLE
Added support for multiple progress bars displayed simultaneously

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,13 +84,13 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
-            <version>3.13.3</version>
+            <version>3.14.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jansi</artifactId>
-            <version>3.13.3</version>
+            <version>3.14.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/me/tongfei/progressbar/ConsoleProgressBarConsumer.java
+++ b/src/main/java/me/tongfei/progressbar/ConsoleProgressBarConsumer.java
@@ -1,13 +1,11 @@
 package me.tongfei.progressbar;
 
-import org.jline.terminal.Terminal;
-
-import java.io.IOException;
 import java.io.PrintStream;
 
 /**
  * Progress bar consumer that prints the progress bar state to console.
  * By default {@link System#err} is used as {@link PrintStream}.
+ *
  * @author Tongfei Chen
  * @author Alex Peelman
  */
@@ -15,7 +13,9 @@ public class ConsoleProgressBarConsumer implements ProgressBarConsumer {
 
     private static int consoleRightMargin = 2;
     private final PrintStream out;
-    private Terminal terminal = Util.getTerminal();
+
+    private boolean initialized = false;
+    int position = -1;
 
     ConsoleProgressBarConsumer() {
         this(System.err);
@@ -23,26 +23,72 @@ public class ConsoleProgressBarConsumer implements ProgressBarConsumer {
 
     ConsoleProgressBarConsumer(PrintStream out) {
         this.out = out;
+        Util.terminalConsumers.add(this);
     }
 
     @Override
     public int getMaxProgressLength() {
-        return Util.getTerminalWidth(terminal) - consoleRightMargin;
+        return Util.getTerminalWidth() - consoleRightMargin;
     }
 
     @Override
     public void accept(String str) {
-        out.print('\r'); // before update
+        if (Util.cursorMovementSupport()) {
+            synchronized (out) {
+                if (initialized) {
+                    int currentPosition = Util.currentCursorPosition();
+                    if (currentPosition >= 0) {
+                        moveCursorUp(currentPosition - position);
+                        replaceLine(str);
+                        moveCursorDown(currentPosition - position);
+                    }
+                } else {
+                    position = Util.currentCursorPosition();
+
+                    // prevent issues caused by reaching terminal height => multiple progressbars having same (maximum) cursor position
+                    if (position == Util.getTerminal().getHeight() - 1) {
+                        Util.terminalConsumers.forEach(c -> {
+                            c.position--;
+                        });
+                    }
+
+                    out.print('\r');
+                    out.println(str);
+                    initialized = true;
+                }
+            }
+        } else {
+            replaceLine(str);
+        }
+    }
+
+    private void moveCursorUp(int count) {
+        if (count <= 0) {
+            return;
+        }
+        out.print(String.format("\u001b[%sA", count));
+    }
+
+    private void moveCursorDown(int count) {
+        if (count <= 0) {
+            return;
+        }
+        out.print(String.format("\u001b[%sB", count));
+    }
+
+    private void replaceLine(String str) {
+        out.print('\r');
         out.print(str);
+        out.print('\r');
     }
 
     @Override
     public void close() {
-        out.println();
-        out.flush();
-        try {
-            terminal.close();
+        if (!Util.cursorMovementSupport()) {
+            out.println();
         }
-        catch (IOException ignored) { /* noop */ }
+        out.flush();
+        Util.terminalConsumers.remove(this);
+        Util.closeTerminal();
     }
 }

--- a/src/main/java/me/tongfei/progressbar/ProgressThread.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressThread.java
@@ -1,15 +1,5 @@
 package me.tongfei.progressbar;
 
-import java.io.PrintStream;
-import java.io.IOException;
-import java.text.DecimalFormat;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.function.Consumer;
-
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-
 /**
  * @author Tongfei Chen
  * @since 0.5.0
@@ -18,7 +8,7 @@ class ProgressThread implements Runnable {
 
     private ProgressState progress;
     private ProgressBarRenderer renderer;
-    private long updateInterval;
+    long updateInterval;
     private ProgressBarConsumer consumer;
 
     ProgressThread(
@@ -40,18 +30,12 @@ class ProgressThread implements Runnable {
 
     void closeConsumer() {
         consumer.close();
+        // force refreshing after being "interrupted"
+        refresh();
     }
 
     public void run() {
-        try {
-            while (!Thread.interrupted()) {
-                refresh();
-                Thread.sleep(updateInterval);
-            }
-        } catch (InterruptedException ignored) {
-            refresh();
-            // force refreshing after being interrupted
-        }
+        refresh();
     }
 
 }


### PR DESCRIPTION

 - defaults to "single line" behaviour when terminal does not support moving cursor
 - using ScheduledThreadPoolExecutor with single daemon thread (that does not prevent the JVM from exiting)
   - simplifies thread-safety and ensures only single thread is moving cursor

Fixes #11 