### PR TITLE
Added support for multiple progress bars displayed simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+ * `0.8.1`:
+     - Bugfixes:
+       - Fixed the bug of possible negative suffix length (PR #58). Thanks @kristofarkas !
+       - Fixed the issue of stepping by -1 when wrapped input stream is depleted (#60, PR #61). Thanks @mordechaim !
+       - Default value for initial max in progress bar builders should be -1, not 0 (#60, PR #61). Thanks @mordechaim !
+     - Dependency version bump.
+
  * `0.8.0`:
      - Supports loggers (PR #54) by factoring out progress bar consumers and renderers. This allows progress bars to be used with logging libraries such as SLF4J, hence fixing #12 and #18. Thanks @alexpeelman !
      - Dependency version bump.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
  * `0.8.1`:
      - Bugfixes:
-       - Fixed the bug of possible negative suffix length (PR #58). Thanks @kristofarkas !
-       - Fixed the issue of stepping by -1 when wrapped input stream is depleted (#60, PR #61). Thanks @mordechaim !
-       - Default value for initial max in progress bar builders should be -1, not 0 (#60, PR #61). Thanks @mordechaim !
+         - Fixed the bug of possible negative suffix length (PR #58). Thanks @kristofarkas !
+         - Fixed the issue of stepping by -1 when wrapped input stream is depleted (#60, PR #61). Thanks @mordechaim !
+         - Default value for initial max in progress bar builders should be -1, not 0 (#60, PR #61). Thanks @mordechaim !
      - Dependency version bump.
 
  * `0.8.0`:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015--2019 Tongfei Chen
+Copyright (c) 2015--2020 Tongfei Chen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A console progress bar for JVM with minimal runtime overhead.
 
 Menlo, 
 [Fira Mono](https://github.com/mozilla/Fira), 
-[Source Code Pro](https://github.com/adobe-fonts/source-code-pro) or 
+[Source Code Pro](https://github.com/adobe-fonts/source-code-pro),
+[Iosevka](https://github.com/be5invis/Iosevka), or 
 [SF Mono](https://developer.apple.com/fonts/) are recommended for optimal visual effects.
 
 For Consolas or Andale Mono fonts, use `ProgressBarStyle.ASCII` because the box-drawing glyphs are not aligned properly in these fonts.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Maven:
   <dependency>
       <groupId>me.tongfei</groupId>
       <artifactId>progressbar</artifactId>
-      <version>0.8.0</version>
+      <version>0.8.1</version>
   </dependency>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,12 +10,12 @@ Depending on your build tool, add the following setting.
   <dependency>
       <groupId>me.tongfei</groupId>
       <artifactId>progressbar</artifactId>
-      <version>0.8.0</version>
+      <version>0.8.1</version>
   </dependency>
 ```
 
 ``` groovy fct_label="Gradle"
-compile 'me.tongfei:progressbar:0.8.0'
+compile 'me.tongfei:progressbar:0.8.1'
 ```
 
 #### Getting started

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: 'Progressbar 0.8.0'
-site_description: 'A console progress bar for Java/JVM'
+site_name: 'Progressbar 0.8.1'
+site_description: 'A terminal progress bar for Java/JVM'
 site_author: 'Tongfei Chen'
-copyright: 'Copyright &copy; 2015-2019 Tongfei Chen'
+copyright: 'Copyright &copy; 2015-2020 Tongfei Chen'
 
 theme:
   name: 'material'

--- a/pom.xml
+++ b/pom.xml
@@ -84,13 +84,13 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
-            <version>3.13.3</version>
+            <version>3.14.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jansi</artifactId>
-            <version>3.13.3</version>
+            <version>3.14.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,10 @@
     <url>http://github.com/ctongfei/progressbar</url>
 
     <properties>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <maven.compiler.target>1.8</maven.compiler.target>
-      <maven.compiler.source>1.8</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <jline.version>3.14.0</jline.version>
     </properties>
 
     <licenses>
@@ -84,13 +85,13 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
-            <version>3.14.0</version>
+            <version>${jline.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jansi</artifactId>
-            <version>3.14.0</version>
+            <version>${jline.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
 
     <groupId>me.tongfei</groupId>
     <artifactId>progressbar</artifactId>
-    <version>0.8.0</version>
+    <version>0.8.1</version>
     <name>progressbar</name>
-    <description>A console-based progress bar for JVM</description>
+    <description>A terminal-based progress bar for JVM</description>
     <url>http://github.com/ctongfei/progressbar</url>
 
     <properties>
@@ -70,25 +70,33 @@
             <id>alexpeelman</id>
             <name>Alex Peelman</name>
         </developer>
+        <developer>
+            <id>kristofarkas</id>
+            <name>Kristof Farkas-Pall</name>
+        </developer>
+        <developer>
+            <id>mordechaim</id>
+            <name>Mordechai Meisels</name>
+        </developer>
     </developers>
 
     <dependencies>
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline</artifactId>
-            <version>3.13.2</version>
+            <version>3.13.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jansi</artifactId>
-            <version>3.13.2</version>
+            <version>3.13.3</version>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/me/tongfei/progressbar/ConsoleProgressBarConsumer.java
+++ b/src/main/java/me/tongfei/progressbar/ConsoleProgressBarConsumer.java
@@ -24,7 +24,6 @@ public class ConsoleProgressBarConsumer implements ProgressBarConsumer {
 
     ConsoleProgressBarConsumer(PrintStream out) {
         this.out = out;
-        Util.terminalConsumers.add(this);
     }
 
     @Override
@@ -39,14 +38,10 @@ public class ConsoleProgressBarConsumer implements ProgressBarConsumer {
                 if (initialized) {
                     out.print(moveCursorUp(position) + str + moveCursorDown(position));
                 } else {
-                    position = 0;
-                    Util.terminalConsumers.forEach(c -> {
-                        if (c.position != -1) {
-                            c.position++;
-                        }
-                    });
-
+                    Util.terminalConsumers.forEach(c -> c.position++);
+                    Util.terminalConsumers.add(this);
                     out.println(MOVE_CURSOR_TO_LINE_START + str);
+                    position = 1;
                     initialized = true;
                 }
             }

--- a/src/main/java/me/tongfei/progressbar/ConsoleProgressBarConsumer.java
+++ b/src/main/java/me/tongfei/progressbar/ConsoleProgressBarConsumer.java
@@ -2,6 +2,8 @@ package me.tongfei.progressbar;
 
 import java.io.PrintStream;
 
+import static me.tongfei.progressbar.TerminalUtils.MOVE_CURSOR_TO_LINE_START;
+
 /**
  * Progress bar consumer that prints the progress bar state to console.
  * By default {@link System#err} is used as {@link PrintStream}.
@@ -11,21 +13,11 @@ import java.io.PrintStream;
  */
 public class ConsoleProgressBarConsumer implements ProgressBarConsumer {
 
-    private static final char MOVE_CURSOR_TO_LINE_START = '\r';
     private static int consoleRightMargin = 2;
-    private final boolean cursorMovementSupport;
     final PrintStream out;
 
-    private boolean initialized = false;
-    int position = -1;
-
-    ConsoleProgressBarConsumer() {
-        this(System.err);
-    }
-
-    ConsoleProgressBarConsumer(PrintStream out) {
+    public ConsoleProgressBarConsumer(PrintStream out) {
         this.out = out;
-        cursorMovementSupport = TerminalUtils.cursorMovementSupport();
     }
 
     @Override
@@ -35,43 +27,12 @@ public class ConsoleProgressBarConsumer implements ProgressBarConsumer {
 
     @Override
     public void accept(String str) {
-        if (cursorMovementSupport) {
-            synchronized (out) {
-                if (initialized) {
-                    out.print(moveCursorUp(position) + str + moveCursorDown(position));
-                } else {
-                    TerminalUtils.filterActiveConsumers(ConsoleProgressBarConsumer.class).forEach(c -> c.position++);
-                    TerminalUtils.activeConsumers.add(this);
-                    out.println(MOVE_CURSOR_TO_LINE_START + str);
-                    position = 1;
-                    initialized = true;
-                }
-            }
-        } else {
-            out.print(MOVE_CURSOR_TO_LINE_START + str);
-        }
-    }
-
-    private String moveCursorUp(int count) {
-        if (count <= 0) {
-            return "";
-        }
-        return String.format("\u001b[%sA", count) + MOVE_CURSOR_TO_LINE_START;
-    }
-
-    private String moveCursorDown(int count) {
-        if (count <= 0) {
-            return "";
-        }
-        return String.format("\u001b[%sB", count) + MOVE_CURSOR_TO_LINE_START;
+        out.print(MOVE_CURSOR_TO_LINE_START + str);
     }
 
     @Override
     public void close() {
-        if (!cursorMovementSupport) {
-            out.println();
-        }
+        out.println();
         out.flush();
-        TerminalUtils.activeConsumers.remove(this);
     }
 }

--- a/src/main/java/me/tongfei/progressbar/DelegatingProgressBarConsumer.java
+++ b/src/main/java/me/tongfei/progressbar/DelegatingProgressBarConsumer.java
@@ -13,7 +13,7 @@ public class DelegatingProgressBarConsumer implements ProgressBarConsumer {
     private final Consumer<String> consumer;
 
     public DelegatingProgressBarConsumer(Consumer<String> consumer) {
-        this(consumer, Util.getTerminalWidth());
+        this(consumer, TerminalUtils.getTerminalWidth());
     }
 
     public DelegatingProgressBarConsumer(Consumer<String> consumer, int maxProgressLength) {

--- a/src/main/java/me/tongfei/progressbar/InteractiveConsoleProgressBarConsumer.java
+++ b/src/main/java/me/tongfei/progressbar/InteractiveConsoleProgressBarConsumer.java
@@ -1,0 +1,39 @@
+package me.tongfei.progressbar;
+
+import java.io.PrintStream;
+
+import static me.tongfei.progressbar.TerminalUtils.*;
+
+/**
+ * Progress bar consumer for terminals supporting moving cursor up/down.
+ *
+ * @author Martin Vehovsky
+ */
+public class InteractiveConsoleProgressBarConsumer extends ConsoleProgressBarConsumer {
+
+    private boolean initialized = false;
+    int position = 1;
+
+    public InteractiveConsoleProgressBarConsumer(PrintStream out) {
+        super(out);
+    }
+
+    @Override
+    public void accept(String str) {
+        if (!initialized) {
+            TerminalUtils.filterActiveConsumers(InteractiveConsoleProgressBarConsumer.class).forEach(c -> c.position++);
+            TerminalUtils.activeConsumers.add(this);
+            out.println(MOVE_CURSOR_TO_LINE_START + str);
+            initialized = true;
+            return;
+        }
+
+        out.print(moveCursorUp(position) + str + moveCursorDown(position));
+    }
+
+    @Override
+    public void close() {
+        out.flush();
+        TerminalUtils.activeConsumers.remove(this);
+    }
+}

--- a/src/main/java/me/tongfei/progressbar/ProgressBarBuilder.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBarBuilder.java
@@ -10,7 +10,7 @@ import java.text.DecimalFormat;
 public class ProgressBarBuilder {
 
     private String task = "";
-    private long initialMax = 0;
+    private long initialMax = -1;
     private int updateIntervalMillis = 1000;
     private ProgressBarStyle style = ProgressBarStyle.COLORFUL_UNICODE_BLOCK;
     private ProgressBarConsumer consumer = null;

--- a/src/main/java/me/tongfei/progressbar/ProgressBarBuilder.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBarBuilder.java
@@ -2,6 +2,8 @@ package me.tongfei.progressbar;
 
 import java.text.DecimalFormat;
 
+import static me.tongfei.progressbar.Util.createConsoleConsumer;
+
 /**
  * Builder class for {@link ProgressBar}s.
  * @author Tongfei Chen
@@ -64,7 +66,7 @@ public class ProgressBarBuilder {
 
     public ProgressBar build() {
         if (consumer == null)
-            consumer = new ConsoleProgressBarConsumer();
+            consumer = createConsoleConsumer();
 
         return new ProgressBar(
                 task,

--- a/src/main/java/me/tongfei/progressbar/ProgressThread.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressThread.java
@@ -10,6 +10,7 @@ class ProgressThread implements Runnable {
     private ProgressBarRenderer renderer;
     long updateInterval;
     private ProgressBarConsumer consumer;
+    private boolean active = true;
 
     ProgressThread(
             ProgressState progress,
@@ -28,21 +29,18 @@ class ProgressThread implements Runnable {
         consumer.accept(rendered);
     }
 
-    void closeConsumer() {
-        if (consumer instanceof ConsoleProgressBarConsumer) {
-            synchronized (((ConsoleProgressBarConsumer) consumer).out) {
-                // force refreshing after being "interrupted"
-                refresh();
-                consumer.close();
-            }
-            return;
-        }
-        // force refreshing after being "interrupted"
-        refresh();
-        consumer.close();
+    public void setActive(boolean active) {
+        this.active = active;
     }
 
+    @Override
     public void run() {
+        if (!active) {
+            refresh();
+            consumer.close();
+            return;
+        }
+
         refresh();
     }
 

--- a/src/main/java/me/tongfei/progressbar/ProgressThread.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressThread.java
@@ -1,15 +1,5 @@
 package me.tongfei.progressbar;
 
-import java.io.PrintStream;
-import java.io.IOException;
-import java.text.DecimalFormat;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.function.Consumer;
-
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-
 /**
  * @author Tongfei Chen
  * @since 0.5.0
@@ -18,7 +8,7 @@ class ProgressThread implements Runnable {
 
     private ProgressState progress;
     private ProgressBarRenderer renderer;
-    private long updateInterval;
+    long updateInterval;
     private ProgressBarConsumer consumer;
 
     ProgressThread(
@@ -40,18 +30,12 @@ class ProgressThread implements Runnable {
 
     void closeConsumer() {
         consumer.close();
+        // force refreshing after being "interrupted"
+        refresh();
     }
 
     public void run() {
-        try {
-            while (!Thread.interrupted()) {
-                refresh();
-                Thread.sleep(updateInterval);
-            }
-        } catch (InterruptedException ignored) {
-            refresh();
-            // force refreshing after being interrupted
-        }
+        refresh();
     }
 
 }

--- a/src/main/java/me/tongfei/progressbar/ProgressThread.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressThread.java
@@ -38,6 +38,7 @@ class ProgressThread implements Runnable {
         if (!active) {
             refresh();
             consumer.close();
+            TerminalUtils.closeTerminal();
             return;
         }
 

--- a/src/main/java/me/tongfei/progressbar/ProgressThread.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressThread.java
@@ -29,9 +29,17 @@ class ProgressThread implements Runnable {
     }
 
     void closeConsumer() {
-        consumer.close();
+        if (consumer instanceof ConsoleProgressBarConsumer) {
+            synchronized (((ConsoleProgressBarConsumer) consumer).out) {
+                // force refreshing after being "interrupted"
+                refresh();
+                consumer.close();
+            }
+            return;
+        }
         // force refreshing after being "interrupted"
         refresh();
+        consumer.close();
     }
 
     public void run() {

--- a/src/main/java/me/tongfei/progressbar/TerminalUtils.java
+++ b/src/main/java/me/tongfei/progressbar/TerminalUtils.java
@@ -49,8 +49,10 @@ public class TerminalUtils {
 
     synchronized static void closeTerminal() {
         try {
-            terminal.close();
-            terminal = null;
+            if (terminal != null) {
+                terminal.close();
+                terminal = null;
+            }
         } catch (IOException ignored) { /* noop */ }
     }
 

--- a/src/main/java/me/tongfei/progressbar/TerminalUtils.java
+++ b/src/main/java/me/tongfei/progressbar/TerminalUtils.java
@@ -1,0 +1,73 @@
+package me.tongfei.progressbar;
+
+import java.io.IOException;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Stream;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+
+import static org.jline.utils.InfoCmp.Capability.cursor_down;
+import static org.jline.utils.InfoCmp.Capability.cursor_up;
+
+/**
+ * @author Martin Vehovsky
+ * @since 0.9.0
+ */
+class TerminalUtils {
+
+    private static int defaultTerminalWidth = 80;
+
+    public static Queue<ProgressBarConsumer> activeConsumers = new ConcurrentLinkedQueue<>();
+
+    synchronized public static int getTerminalWidth() {
+        Terminal terminal = getTerminal();
+
+        if (terminal != null) {
+            int width = terminal.getWidth();
+            close(terminal);
+
+            // Workaround for issue #23 under IntelliJ
+            if (width >= 10) {
+                return width;
+            }
+        }
+
+        return defaultTerminalWidth;
+    }
+
+    synchronized public static boolean cursorMovementSupport() {
+        Terminal terminal = getTerminal();
+        boolean cursorMovementSupported = false;
+        if (terminal != null) {
+            cursorMovementSupported = terminal.getStringCapability(cursor_up) != null && terminal.getStringCapability(cursor_down) != null;
+            close(terminal);
+        }
+        return cursorMovementSupported;
+    }
+
+    public static <T extends ProgressBarConsumer> Stream<T> filterActiveConsumers(Class<T> clazz) {
+        return activeConsumers.stream()
+                .filter(clazz::isInstance)
+                .map(clazz::cast);
+    }
+
+    private static void close(Terminal terminal) {
+        try {
+            terminal.close();
+        } catch (IOException ignored) { /* noop */ }
+    }
+
+    private static Terminal getTerminal() {
+        try {
+            // Issue #42
+            // Defaulting to a dumb terminal when a supported terminal can not be correctly created
+            // see https://github.com/jline/jline3/issues/291
+            return TerminalBuilder.builder().dumb(true).build();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/me/tongfei/progressbar/TerminalUtils.java
+++ b/src/main/java/me/tongfei/progressbar/TerminalUtils.java
@@ -18,23 +18,21 @@ import static org.jline.utils.InfoCmp.Capability.cursor_up;
 public class TerminalUtils {
 
     public static final char MOVE_CURSOR_TO_LINE_START = '\r';
+    public static final char ESCAPE_CHAR = '\u001b';
 
-    private static int defaultTerminalWidth = 80;
+    private static final int defaultTerminalWidth = 80;
     private static Boolean cursorMovementSupported = null;
 
+    private static Terminal terminal = null;
     public static Queue<ProgressBarConsumer> activeConsumers = new ConcurrentLinkedQueue<>();
 
     synchronized public static int getTerminalWidth() {
         Terminal terminal = getTerminal();
+        int width = terminal.getWidth();
 
-        if (terminal != null) {
-            int width = terminal.getWidth();
-            close(terminal);
-
-            // Workaround for issue #23 under IntelliJ
-            if (width >= 10) {
-                return width;
-            }
+        // Workaround for issue #23 under IntelliJ
+        if (width >= 10) {
+            return width;
         }
 
         return defaultTerminalWidth;
@@ -43,14 +41,17 @@ public class TerminalUtils {
     synchronized public static boolean cursorMovementSupport() {
         if (cursorMovementSupported == null) {
             Terminal terminal = getTerminal();
-            if (terminal != null) {
-                cursorMovementSupported = terminal.getStringCapability(cursor_up) != null && terminal.getStringCapability(cursor_down) != null;
-                close(terminal);
-            } else {
-                cursorMovementSupported = false;
-            }
+            cursorMovementSupported = terminal.getStringCapability(cursor_up) != null && terminal.getStringCapability(cursor_down) != null;
+            closeTerminal();
         }
         return cursorMovementSupported;
+    }
+
+    synchronized static void closeTerminal() {
+        try {
+            terminal.close();
+            terminal = null;
+        } catch (IOException ignored) { /* noop */ }
     }
 
     public static <T extends ProgressBarConsumer> Stream<T> filterActiveConsumers(Class<T> clazz) {
@@ -60,28 +61,40 @@ public class TerminalUtils {
     }
 
     public static String moveCursorUp(int count) {
-        return String.format("\u001b[%sA", count) + MOVE_CURSOR_TO_LINE_START;
+        return String.format(ESCAPE_CHAR + "[%sA", count) + MOVE_CURSOR_TO_LINE_START;
     }
 
     public static String moveCursorDown(int count) {
-        return String.format("\u001b[%sB", count) + MOVE_CURSOR_TO_LINE_START;
+        return String.format(ESCAPE_CHAR + "[%sB", count) + MOVE_CURSOR_TO_LINE_START;
     }
 
-    static void close(Terminal terminal) {
-        try {
-            terminal.close();
-        } catch (IOException ignored) { /* noop */ }
-    }
-
+    /**
+     * <ul>
+     *     <li>Creating terminal is relatively expensive, usually takes between 5-10ms.
+     *         <ul>
+     *             <li>If updateInterval is set under 10ms creating new terminal for on every re-render of progress bar could be a problem.</li>
+     *             <li>Especially when multiple progress bars are running in parallel.</li>
+     *         </ul>
+     *     </li>
+     *     <li>Another problem with {@link Terminal} is that once created you can create another instance (say from different thread), but this instance will be
+     *     "dumb". Until previously created terminal will be closed.
+     *     </li>
+     * </ul>
+     *
+     * @return
+     */
     static Terminal getTerminal() {
-        try {
-            // Issue #42
-            // Defaulting to a dumb terminal when a supported terminal can not be correctly created
-            // see https://github.com/jline/jline3/issues/291
-            return TerminalBuilder.builder().dumb(true).build();
-        } catch (IOException e) {
-            return null;
+        if (terminal == null) {
+            try {
+                // Issue #42
+                // Defaulting to a dumb terminal when a supported terminal can not be correctly created
+                // see https://github.com/jline/jline3/issues/291
+                terminal = TerminalBuilder.builder().dumb(true).build();
+            } catch (IOException e) {
+                throw new RuntimeException("This should never happen! Dump terminal should have been created.");
+            }
         }
+        return terminal;
     }
 
 }

--- a/src/main/java/me/tongfei/progressbar/Util.java
+++ b/src/main/java/me/tongfei/progressbar/Util.java
@@ -4,15 +4,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.jline.utils.InfoCmp;
 
 /**
  * @author Tongfei Chen
@@ -26,12 +19,6 @@ class Util {
         thread.setDaemon(true);
         return thread;
     });
-
-    static List<ConsoleProgressBarConsumer> terminalConsumers = Collections.synchronizedList(new ArrayList<>());
-
-    private static int defaultTerminalWidth = 80;
-    private static boolean cursorMovementSupport = false;
-    private static Terminal terminal = null;
 
     static String repeat(char c, int n) {
         if (n <= 0) return "";
@@ -54,50 +41,4 @@ class Util {
         }
         return -1;
     }
-
-    static boolean cursorMovementSupport() {
-        getTerminal();
-        return cursorMovementSupport;
-    }
-
-    static void closeTerminal() {
-        if (terminalConsumers.size() == 0) {
-            try {
-                terminal.close();
-            } catch (IOException ignored) { /* noop */ }
-            terminal = null;
-            cursorMovementSupport = false;
-        }
-    }
-
-    static Terminal getTerminal() {
-        if (terminal == null) {
-            try {
-                // Issue #42
-                // Defaulting to a dumb terminal when a supported terminal can not be correctly created
-                // see https://github.com/jline/jline3/issues/291
-                terminal = TerminalBuilder.builder().dumb(true).build();
-
-                if (!terminal.getType().equals(Terminal.TYPE_DUMB)) {
-                    terminal.enterRawMode();
-                }
-            } catch (IOException ignored) {
-            }
-            cursorMovementSupport = terminal.getStringCapability(InfoCmp.Capability.cursor_up) != null
-                    && terminal.getStringCapability(InfoCmp.Capability.cursor_down) != null;
-        }
-        return terminal;
-    }
-
-    static int getTerminalWidth(Terminal terminal) {
-        if (terminal != null && terminal.getWidth() >= 10) // Workaround for issue #23 under IntelliJ
-            return terminal.getWidth();
-        else return defaultTerminalWidth;
-    }
-
-    static int getTerminalWidth() {
-        Terminal terminal = getTerminal();
-        return getTerminalWidth(terminal);
-    }
-
 }

--- a/src/main/java/me/tongfei/progressbar/Util.java
+++ b/src/main/java/me/tongfei/progressbar/Util.java
@@ -3,6 +3,7 @@ package me.tongfei.progressbar;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -19,6 +20,17 @@ class Util {
         thread.setDaemon(true);
         return thread;
     });
+
+    static ConsoleProgressBarConsumer createConsoleConsumer() {
+        return createConsoleConsumer(System.err);
+    }
+
+    static ConsoleProgressBarConsumer createConsoleConsumer(PrintStream out) {
+        if (TerminalUtils.cursorMovementSupport()) {
+            return new InteractiveConsoleProgressBarConsumer(out);
+        }
+        return new ConsoleProgressBarConsumer(out);
+    }
 
     static String repeat(char c, int n) {
         if (n <= 0) return "";

--- a/src/main/java/me/tongfei/progressbar/Util.java
+++ b/src/main/java/me/tongfei/progressbar/Util.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
-import org.jline.terminal.Cursor;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.InfoCmp;
@@ -88,16 +87,6 @@ class Util {
                     && terminal.getStringCapability(InfoCmp.Capability.cursor_down) != null;
         }
         return terminal;
-    }
-
-    static int currentCursorPosition() {
-        Cursor cursor = getTerminal().getCursorPosition(value -> {
-            //FIXME: what to do about discarded characters??
-        });
-        if (cursor == null) {
-            return 0;
-        }
-        return cursor.getY();
     }
 
     static int getTerminalWidth(Terminal terminal) {

--- a/src/main/java/me/tongfei/progressbar/wrapped/ProgressBarWrappedInputStream.java
+++ b/src/main/java/me/tongfei/progressbar/wrapped/ProgressBarWrappedInputStream.java
@@ -35,14 +35,14 @@ public class ProgressBarWrappedInputStream extends FilterInputStream {
     @Override
     public int read(byte[] b) throws IOException {
         int r = in.read(b);
-        pb.stepBy(r);
+        if (r != -1) pb.stepBy(r);
         return r;
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         int r = in.read(b, off, len);
-        pb.stepBy(r);
+        if (r != -1) pb.stepBy(r);
         return r;
     }
 

--- a/src/test/java/me/tongfei/progressbar/MockProgressBarBuilder.java
+++ b/src/test/java/me/tongfei/progressbar/MockProgressBarBuilder.java
@@ -1,0 +1,28 @@
+package me.tongfei.progressbar;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class MockProgressBarBuilder extends ProgressBarBuilder {
+
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    public MockProgressBarBuilder() {
+        try {
+            setConsumer(new InteractiveConsoleProgressBarConsumer(new PrintStream(out, true, UTF_8.name())));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("This should never happen!");
+        }
+    }
+
+    public String getOutput() {
+        try {
+            return out.toString(UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("This should never happen!");
+        }
+    }
+}


### PR DESCRIPTION
 - defaults to "single line" behavior when terminal does not support moving cursor
 - using ScheduledThreadPoolExecutor with single daemon thread (that does not prevent the JVM from exiting)
   - simplifies thread-safety and ensures only single thread is moving cursor

Fixes #11 