### PR TITLE
Add references to Kotlin extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,8 @@ try (ProgressBar pb = new ProgressBar("Test", 100)) { // name, initial max
 } // progress bar stops automatically after completion of try-with-resource block
 ```
 
+##### Kotlin extensions
+Kotlin DSL-like builders are available at [reimersoftware/progressbar-ktx](https://github.com/reimersoftware/progressbar-ktx).
+
 #### Changelog
 [CHANGELOG](https://github.com/ctongfei/progressbar/blob/master/CHANGELOG.md)

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -1,0 +1,3 @@
+# Kotlin extensions
+
+Kotlin DSL-like builders are available at [reimersoftware/progressbar-ktx](https://github.com/reimersoftware/progressbar-ktx).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,5 +33,6 @@ pages:
   - 'Imperative usage': 'imperative-usage.md'
   - 'Visual styles': 'styles.md'
   - 'Builder pattern': 'builder.md'
+  - 'Kotlin extensions': 'kotlin.md'
   - 'Integrating with loggers': 'loggers.md'
   - 'Changelog': 'changelog.md'


### PR DESCRIPTION
Reference the [reimersoftware/progressbar-ktx](https://github.com/reimersoftware/progressbar-ktx) project for Kotlin extensions of this project.