### PR TITLE
Pass size when wrapping array with ProgressBarBuilder

### DIFF
--- a/src/main/java/me/tongfei/progressbar/ProgressBar.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBar.java
@@ -328,7 +328,7 @@ public class ProgressBar implements AutoCloseable {
      * @return Wrapped array, of type {@link Stream}.
      */
     public static <T> Stream<T> wrap(T[] array, String task) {
-        ProgressBarBuilder pbb = new ProgressBarBuilder().setTaskName(task).setInitialMax(array.length);
+        ProgressBarBuilder pbb = new ProgressBarBuilder().setTaskName(task);
         return wrap(array, pbb);
     }
 
@@ -340,6 +340,7 @@ public class ProgressBar implements AutoCloseable {
      * @return Wrapped array, of type {@link Stream}.
      */
     public static <T> Stream<T> wrap(T[] array, ProgressBarBuilder pbb) {
+        pbb.setInitialMax(array.length);
         return wrap(Arrays.stream(array), pbb);
     }
 


### PR DESCRIPTION
When wrapping an array and customising the `ProgressBar` with a `ProgressBarBuilder`, the size of the array is not used. This change brings arrays in line with `Iterable` and `Spliterator`, which do use the size when known.