### PR TITLE
Optimizing StringDisplayUtils.trimDisplayLength

### DIFF
--- a/src/main/java/me/tongfei/progressbar/StringDisplayUtils.java
+++ b/src/main/java/me/tongfei/progressbar/StringDisplayUtils.java
@@ -29,17 +29,18 @@ class StringDisplayUtils {
     }
 
     static String trimDisplayLength(String s, int maxDisplayLength) {
-        StringBuilder sb = new StringBuilder();
-        int i = 0;
-        int totalLength = 0;
-        while (totalLength < maxDisplayLength) {
-            char c = s.charAt(i);
-            totalLength += getCharDisplayLength(c);
-            if (totalLength > maxDisplayLength) break;
-            i++;
-            sb.append(c);
+        if (maxDisplayLength <= 0) {
+            return "";
         }
-        return sb.toString();
+
+        int totalLength = 0;
+        for (int i = 0; i < s.length(); i++) {
+            totalLength += getCharDisplayLength(s.charAt(i));
+            if (totalLength > maxDisplayLength) {
+                return s.substring(0, i);
+            }
+        }
+        return s;
     }
 
 }

--- a/src/test/java/me/tongfei/progressbar/EastAsianDisplayTest.java
+++ b/src/test/java/me/tongfei/progressbar/EastAsianDisplayTest.java
@@ -18,6 +18,25 @@ public class EastAsianDisplayTest {
     }
 
     @Test
+    void testEastAsianTrimDisplayLength() {
+        assertEquals(StringDisplayUtils.trimDisplayLength("Progress bar", 0), "");
+        assertEquals(StringDisplayUtils.trimDisplayLength("Progress bar", 10), "Progress b");
+        assertEquals(StringDisplayUtils.trimDisplayLength("Progress bar", 15), "Progress bar");
+        assertEquals(StringDisplayUtils.trimDisplayLength("进度条", 0), "");
+        assertEquals(StringDisplayUtils.trimDisplayLength("进度条", 4), "进度");
+        assertEquals(StringDisplayUtils.trimDisplayLength("进度条", 8), "进度条");
+        assertEquals(StringDisplayUtils.trimDisplayLength("进度条", 0), "");
+        assertEquals(StringDisplayUtils.trimDisplayLength("進度條", 4), "進度");
+        assertEquals(StringDisplayUtils.trimDisplayLength("進度條", 8), "進度條");
+        assertEquals(StringDisplayUtils.trimDisplayLength("진행 표시줄", 0), "");
+        assertEquals(StringDisplayUtils.trimDisplayLength("진행 표시줄", 8), "진행 표");
+        assertEquals(StringDisplayUtils.trimDisplayLength("진행 표시줄", 15), "진행 표시줄");
+        assertEquals(StringDisplayUtils.trimDisplayLength("プログレスバー", 0), "");
+        assertEquals(StringDisplayUtils.trimDisplayLength("プログレスバー", 11), "プログレス");
+        assertEquals(StringDisplayUtils.trimDisplayLength("プログレスバー", 18), "プログレスバー");
+    }
+
+    @Test
     void testProgressBarsWithEastAsianScript() {
 
         for (String name : new String[] {"Progress bar", "进度条", "進度條", "진행 표시줄", "プログレスバー"}) {


### PR DESCRIPTION
I found three problems in implementation of StringDisplayUtils.trimDisaplyLength:
1. Using StringBuilder for getting substring (String.substring is recommend for using)
2. Double check on totalLength: "totalLength < maxDisplayLength"
3. Code can get StringIndexOutOfBoundsException, because you don't have check on length of string