### PR TITLE
Improve performance in ConsoleProgressBarConsumer.accept

### DIFF
--- a/src/main/java/me/tongfei/progressbar/ConsoleProgressBarConsumer.java
+++ b/src/main/java/me/tongfei/progressbar/ConsoleProgressBarConsumer.java
@@ -35,9 +35,7 @@ public class ConsoleProgressBarConsumer implements ProgressBarConsumer {
 
     @Override
     public void accept(String str) {
-        int displayLength = StringDisplayUtils.getStringDisplayLength(str);
-        int acceptedLength = Math.min(displayLength, getMaxRenderedLength());
-        out.print(CARRIAGE_RETURN + StringDisplayUtils.trimDisplayLength(str, acceptedLength));
+        out.print(CARRIAGE_RETURN + StringDisplayUtils.trimDisplayLength(str, getMaxRenderedLength()));
     }
 
     @Override


### PR DESCRIPTION
StringDisplayUtils.trimDisplayLength(str, max_display_len) to select string with minimal of total display length this str and given max_display_len. I mean that calculate display length of string is unnecessary. This idea is using in InteractiveConsoleProgressBarConsumer (https://github.com/ctongfei/progressbar/blob/4f86bc3b7d71071fac7a03dd05d7d00a092779cf/src/main/java/me/tongfei/progressbar/InteractiveConsoleProgressBarConsumer.java#L27)