### PR TITLE
Create StringBuilder with known size of string

### DIFF
--- a/src/main/java/me/tongfei/progressbar/DefaultProgressBarRenderer.java
+++ b/src/main/java/me/tongfei/progressbar/DefaultProgressBarRenderer.java
@@ -98,6 +98,9 @@ public class DefaultProgressBarRenderer implements ProgressBarRenderer {
     }
 
     public String render(ProgressState progress, int maxLength) {
+        if (maxLength <= 0) {
+            return "";
+        }
 
         Instant currTime = Instant.now();
         Duration elapsed = Duration.between(progress.startInstant, currTime);
@@ -126,7 +129,7 @@ public class DefaultProgressBarRenderer implements ProgressBarRenderer {
 
         int length = maxLength - prefixLength - suffixLength;
 
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(maxLength);
         sb.append(prefix);
 
         // case of indefinite progress bars


### PR DESCRIPTION
Result of string does have length equal to given argument `maxLength` in `DefaultProgressBarRenderer.render` always. We can use this and create `StringBuilder` with initial size of array equal to `maxLength`