### PR TITLE
Allow ProgressBarBuilder.setETAFunction to be used externally

### DIFF
--- a/src/main/java/me/tongfei/progressbar/ProgressState.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressState.java
@@ -8,7 +8,7 @@ import java.time.Instant;
  * @author Tongfei Chen
  * @since 0.5.0
  */
-class ProgressState {
+public class ProgressState {
 
     String taskName;
     String extraMessage = "";


### PR DESCRIPTION
ProgressState is package-private and setETAFunction's BiFunction includes ProgressState, preventing setETAFunction from being used outside of the package.

Reproducer:
```
import java.util.Optional;

import me.tongfei.progressbar.ProgressBarBuilder;

public class SetETAReproducer {
    public static void main(String[] argv) {
        ProgressBarBuilder pbb = new ProgressBarBuilder();
        pbb.setETAFunction((a, b) -> Optional.empty());
    }
}
```

Run this on the latest released version 0.9.4:
```
$ javac -cp $HOME/.m2/repository/me/tongfei/progressbar/0.9.4/progressbar-0.9.4.jar SetETAReproducer.java
error: ProgressState is not public in me.tongfei.progressbar; cannot be accessed from outside package
SetETAReproducer.java:8: error: ProgressState is not public in me.tongfei.progressbar; cannot be accessed from outside package
        pbb.setETAFunction((a, b) -> Optional.empty());
                           ^
2 errors
```