### PR TITLE
Use finely grained `jline-terminal` rather than bundle jar `jline`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
     <dependencies>
         <dependency>
             <groupId>org.jline</groupId>
-            <artifactId>jline</artifactId>
-            <version>3.23.0</version>
+            <artifactId>jline-terminal</artifactId>
+            <version>3.24.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,4 @@
 module me.tongfei.progressbar {
-    requires org.jline;
+    requires org.jline.terminal;
     exports me.tongfei.progressbar;
 }


### PR DESCRIPTION
While investigating https://github.com/ctongfei/progressbar/issues/158, I was pleased to find the progressbar only actually needs `jline-terminal`. This PR changes the POM and module-info to use that finely grained library.

*This will make it impossible to use progressbar with the jline bundle in modular applications. This however seems more sensible than the current situation which is reversed*