### PR TITLE
Update org.jline dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal</artifactId>
-            <version>3.24.1</version>
+            <version>3.26.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes an NPE

```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because "this.jna" is null
        at org.jline.terminal.TerminalBuilder.doBuild(TerminalBuilder.java:443)
        at org.jline.terminal.TerminalBuilder.build(TerminalBuilder.java:362)
        at me.tongfei.progressbar.TerminalUtils.getTerminal(TerminalUtils.java:83)
```

Refs https://github.com/jline/jline3/issues/930