### PR TITLE
#169: Upgrade jline-terminal to 3.29.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal</artifactId>
-            <version>3.26.2</version>
+            <version>3.29.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes: #169

**Implements**
* changed `jline-terminal` from `3.26.2` to `3.29.0`
* added `dependabot` suggestion

**Comments**
I've upgraded the `jline-terminal` version of `progressbar` and recompiled our native image of `IDEasy` with it.
The disturbing warning messages disappeared and the `progressbar` worked properly.
Last warning message which popped up only once (was not disturbing the progressbar) was: 
```
$ ide -d install android-studio latest
Running commandlet InstallCommandlet[install]
IDE environment variables have been set for D:\projects\ideasy-dev in workspace main
Running command 'C:\Program Files\Git\mingw64\bin\git.exe' with arguments 'rev-parse' '@{u}' ...
Updates are available for the settings repository. If you want to apply the latest changes, call "ide update"
The path D:\projects\_ide\urls\.git\HEAD was last updated PT1H6M14.712S ago and caching duration is PT30M.
Will need to do git pull/clone on D:\projects\_ide\urls because last fetch was some time ago.
Running command 'C:\Program Files\Git\mingw64\bin\git.exe' with arguments 'remote' ...
Running command 'C:\Program Files\Git\mingw64\bin\git.exe' with arguments '--no-pager' 'pull' '--quiet' ...
Running command 'C:\Program Files\Git\mingw64\bin\git.exe' with arguments 'diff-index' '--quiet' 'HEAD' ...
Running command 'C:\Program Files\Git\mingw64\bin\git.exe' with arguments 'ls-files' '--other' '--directory' '--exclude-standard' ...
Resolved version pattern * to version 2025.1.1.10
Resolved version pattern * to version 2025.1.1.10
Resolved version * to 2025.1.1.10 for tool android-studio/android-studio
ANDROID_STUDIO_VERSION=* has been set in SETTINGS@D:\projects\ideasy-dev\settings\ide.properties
Tool android-studio not installed in D:\projects\ideasy-dev\software\android-studio
Start: Install android-studio
Tool android-studio has 0 other tool(s) as dependency
Trying to download android-studio-2025.1.1.10-windows-x64.zip.5 from https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2025.1.1.10/android-studio-2025.1.1.10-windows.zip
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.jline.nativ.JLineNativeLoader in an unnamed module (file:/D:/projects/_ide/installation/bin/ideasy.exe)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

Downloading   5% [===                                                       ]   79/1416MiB (0:00:42 / 0:12:00) 1.9MiB/s
```
But should be fixed in next `Maven` release: https://issues.apache.org/jira/browse/MNG-8248

About the added `dependabot.yml`: I'd suggest to add this to your repository for automatic `dependabot` checks. You probably need to enable it in your security settings though.