### PR TITLE
Time formatting possibilities, and possibility to set length of task name 

### DIFF
--- a/src/main/java/me/tongfei/progressbar/DurationFormatter.java
+++ b/src/main/java/me/tongfei/progressbar/DurationFormatter.java
@@ -1,0 +1,48 @@
+package me.tongfei.progressbar;
+
+import java.time.Duration;
+
+public class DurationFormatter {
+
+    private DurationFormatter() {
+    }
+
+    public static String formatDuration(Duration d) {
+        return formatDuration(d, TimeFormat.DEFAULT);
+    }
+
+    public static String formatDuration(Duration d, TimeFormat format) {
+        final long s = d.getSeconds();
+        switch (format) {
+            case SECONDS:
+                return formatAsSeconds(s);
+            case MINUTES_SECONDS:
+                return formatAsMinutesAndSeconds(s);
+            case ADAPTED: {
+                if (s < 60) {
+                    return formatAsSeconds(s);
+                } else if (s < 3600) {
+                    return formatAsMinutesAndSeconds(s);
+                } else {
+                    return formatAsHoursMinutedAndSeconds(s);
+                }
+            }
+            case DEFAULT:
+            default:
+                return formatAsHoursMinutedAndSeconds(s);
+        }
+    }
+
+    private static String formatAsSeconds(long s) {
+        return String.format("%d", s);
+    }
+
+    private static String formatAsMinutesAndSeconds(long s) {
+        return String.format("%d:%02d", s / 60, s % 60);
+    }
+
+    private static String formatAsHoursMinutedAndSeconds(long s) {
+        return String.format("%d:%02d:%02d", s / 3600, (s % 3600) / 60, s % 60);
+    }
+
+}

--- a/src/main/java/me/tongfei/progressbar/ProgressBar.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBar.java
@@ -71,11 +71,11 @@ public class ProgressBar implements AutoCloseable {
             long processed,
             Duration elapsed
     ) {
-        this(task, initialMax, updateIntervalMillis, continuousUpdate, clearDisplayOnFinish, processed, elapsed,
+        this(task, null, initialMax, updateIntervalMillis, continuousUpdate, clearDisplayOnFinish, processed, elapsed,
                 new DefaultProgressBarRenderer(
                         style, unitName, unitSize,
                         showSpeed, speedFormat, speedUnit,
-                        true, Util::linearEta
+                        true, Util::linearEta, TimeFormat.DEFAULT
                 ),
                 createConsoleConsumer(os)
         );
@@ -85,6 +85,7 @@ public class ProgressBar implements AutoCloseable {
      * Creates a progress bar with the specific name, initial maximum value, customized update interval (default 1s),
      * and the provided progress bar renderer ({@link ProgressBarRenderer}) and consumer ({@link ProgressBarConsumer}).
      * @param task Task name
+     * @param taskFixedLength Fixed length of task name (null equals no fixed length)
      * @param initialMax Initial maximum value
      * @param updateIntervalMillis Update time interval (default value 1000ms)
      * @param continuousUpdate Rerender every time the update interval happens regardless of progress count.
@@ -96,6 +97,7 @@ public class ProgressBar implements AutoCloseable {
      */
     public ProgressBar(
             String task,
+            Integer taskFixedLength,
             long initialMax,
             int updateIntervalMillis,
             boolean continuousUpdate,
@@ -105,7 +107,7 @@ public class ProgressBar implements AutoCloseable {
             ProgressBarRenderer renderer,
             ProgressBarConsumer consumer
     ) {
-        this.progress = new ProgressState(task, initialMax, processed, elapsed);
+        this.progress = new ProgressState(task, taskFixedLength, initialMax, processed, elapsed);
         this.action = new ProgressUpdateAction(progress, renderer, consumer, continuousUpdate, clearDisplayOnFinish);
         scheduledTask = Util.executor.scheduleAtFixedRate(
                 action, 0, updateIntervalMillis, TimeUnit.MILLISECONDS

--- a/src/main/java/me/tongfei/progressbar/ProgressBarBuilder.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBarBuilder.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 public class ProgressBarBuilder {
 
     private String task = "";
+    private Integer taskFixedLength = null;
     private long initialMax = -1;
     private int updateIntervalMillis = 1000;
     private boolean continuousUpdate = false;
@@ -22,6 +23,7 @@ public class ProgressBarBuilder {
     private boolean clearDisplayOnFinish = false;
     private String unitName = "";
     private long unitSize = 1;
+    private TimeFormat timeFormat = TimeFormat.DEFAULT;
     private boolean showSpeed = false;
     private boolean hideEta = false;
     private Function<ProgressState, Optional<Duration>> eta = Util::linearEta;
@@ -37,6 +39,11 @@ public class ProgressBarBuilder {
 
     public ProgressBarBuilder setTaskName(String task) {
         this.task = task;
+        return this;
+    }
+
+    public ProgressBarBuilder setTaskFixedLength(Integer fixedLength) {
+        this.taskFixedLength = fixedLength;
         return this;
     }
 
@@ -90,6 +97,11 @@ public class ProgressBarBuilder {
         return this;
     }
 
+    public ProgressBarBuilder setTimeFormat(TimeFormat timeFormat) {
+        this.timeFormat = timeFormat;
+        return this;
+    }
+
     public ProgressBarBuilder showSpeed() {
         return showSpeed(new DecimalFormat("#.0"));
     }
@@ -130,6 +142,7 @@ public class ProgressBarBuilder {
     public ProgressBar build() {
         return new ProgressBar(
                 task,
+                taskFixedLength,
                 initialMax,
                 updateIntervalMillis,
                 continuousUpdate,
@@ -138,9 +151,9 @@ public class ProgressBarBuilder {
                 elapsed,
                 (renderer == null
                         ? new DefaultProgressBarRenderer(
-                                style, unitName, unitSize,
+                        style, unitName, unitSize,
                         showSpeed, speedFormat, speedUnit,
-                        !hideEta, eta)
+                        !hideEta, eta, timeFormat)
                         : renderer
                 ),
                 (consumer == null

--- a/src/main/java/me/tongfei/progressbar/ProgressState.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressState.java
@@ -11,12 +11,13 @@ import java.time.Instant;
 public class ProgressState {
 
     String taskName;
+
+    private final Integer taskFixedLength;
+
     String extraMessage = "";
 
     boolean indefinite = false;
 
-    //  0             start     current        max
-    //  [===============|=========>             ]
     long start;
     long current;
     long max;
@@ -27,8 +28,9 @@ public class ProgressState {
     volatile boolean alive = true;
     volatile boolean paused = false;
 
-    ProgressState(String taskName, long initialMax, long startFrom, Duration elapsedBeforeStart) {
+    ProgressState(String taskName, Integer taskFixedLength, long initialMax, long startFrom, Duration elapsedBeforeStart) {
         this.taskName = taskName;
+        this.taskFixedLength = taskFixedLength;
         if (initialMax < 0)
             indefinite = true;
         else this.max = initialMax;
@@ -40,7 +42,16 @@ public class ProgressState {
     }
 
     public String getTaskName() {
+        if (taskFixedLength != null) {
+            return getPaddedTaskName(taskName, taskFixedLength);
+        }
         return taskName;
+    }
+
+    private String getPaddedTaskName(String task, int length) {
+        final String str = task.length() < length ? task : task.substring(0, length);
+        final String format = "%-" + length + "s";
+        return String.format(format, str);
     }
 
     public synchronized String getExtraMessage() {

--- a/src/main/java/me/tongfei/progressbar/TimeFormat.java
+++ b/src/main/java/me/tongfei/progressbar/TimeFormat.java
@@ -1,0 +1,8 @@
+package me.tongfei.progressbar;
+
+public enum TimeFormat {
+    DEFAULT,
+    ADAPTED,
+    SECONDS,
+    MINUTES_SECONDS
+}

--- a/src/main/java/me/tongfei/progressbar/Util.java
+++ b/src/main/java/me/tongfei/progressbar/Util.java
@@ -39,11 +39,6 @@ class Util {
         return new String(s);
     }
 
-    static String formatDuration(Duration d) {
-        long s = d.getSeconds();
-        return String.format("%d:%02d:%02d", s / 3600, (s % 3600) / 60, s % 60);
-    }
-
     static Optional<Duration> linearEta(ProgressState progress) {
         if (progress.getMax() <= 0 || progress.isIndefinite()) return Optional.empty();
         else if (progress.getCurrent() - progress.getStart() == 0) return Optional.empty();

--- a/src/test/java/me/tongfei/progressbar/DurationFormatterTest.java
+++ b/src/test/java/me/tongfei/progressbar/DurationFormatterTest.java
@@ -1,0 +1,42 @@
+package me.tongfei.progressbar;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DurationFormatterTest {
+
+    @Test
+    void testFormatWhenSeconds() {
+        assertEquals("5", DurationFormatter.formatDuration(Duration.ofSeconds(5), TimeFormat.SECONDS));
+        assertEquals("22", DurationFormatter.formatDuration(Duration.ofSeconds(22), TimeFormat.SECONDS));
+        assertEquals("63", DurationFormatter.formatDuration(Duration.ofSeconds(63), TimeFormat.SECONDS));
+        assertEquals("3682", DurationFormatter.formatDuration(Duration.ofSeconds(3682), TimeFormat.SECONDS));
+    }
+
+    @Test
+    void testFormatWhenMinutesAndSeconds() {
+        assertEquals("0:05", DurationFormatter.formatDuration(Duration.ofSeconds(5), TimeFormat.MINUTES_SECONDS));
+        assertEquals("0:22", DurationFormatter.formatDuration(Duration.ofSeconds(22), TimeFormat.MINUTES_SECONDS));
+        assertEquals("1:03", DurationFormatter.formatDuration(Duration.ofSeconds(63), TimeFormat.MINUTES_SECONDS));
+        assertEquals("61:22", DurationFormatter.formatDuration(Duration.ofSeconds(3682), TimeFormat.MINUTES_SECONDS));
+    }
+
+    @Test
+    void testFormatWhenAdapted() {
+        assertEquals("5", DurationFormatter.formatDuration(Duration.ofSeconds(5), TimeFormat.ADAPTED));
+        assertEquals("22", DurationFormatter.formatDuration(Duration.ofSeconds(22), TimeFormat.ADAPTED));
+        assertEquals("1:03", DurationFormatter.formatDuration(Duration.ofSeconds(63), TimeFormat.ADAPTED));
+        assertEquals("1:01:22", DurationFormatter.formatDuration(Duration.ofSeconds(3682), TimeFormat.ADAPTED));
+    }
+
+    @Test
+    void testFormatWhenDefault() {
+        assertEquals("0:00:05", DurationFormatter.formatDuration(Duration.ofSeconds(5), TimeFormat.DEFAULT));
+        assertEquals("0:00:22", DurationFormatter.formatDuration(Duration.ofSeconds(22), TimeFormat.DEFAULT));
+        assertEquals("0:01:03", DurationFormatter.formatDuration(Duration.ofSeconds(63), TimeFormat.DEFAULT));
+        assertEquals("1:01:22", DurationFormatter.formatDuration(Duration.ofSeconds(3682), TimeFormat.DEFAULT));
+    }
+}


### PR DESCRIPTION
Added some parameters to ProgressBarBuilder:
* taskFixedLength
* timeFormat

Added enum TimeFormat:
    DEFAULT, // Duration time and eta will be displayed as before
    ADAPTED, // Duration time and eta will be displayed as seconds when under a minute (e.g. 5, 22, etc), as minuted and seconds when under an hour (e.g. 0:05, 0:22, 1:05, etc), and as hour, minutes and seconds when an hour and above
    SECONDS, // Duration time and eta will be displayed as seconds (e.g. 5, 22, 65, ...)
    MINUTES_SECONDS// Duration time and eta will be displayed as minutes and seconds (e.g. 0:05, 0:22, 1:05, .etc)

Made code changes to handle these parameters