### PR TITLE
0.10.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
  * `0.10.2`:
+    - Improvements:
+      - Restored JDK 8 compatibility by using a multi-release JAR. The library now works on JDK 8+ while still providing JPMS module support for JDK 9+.
     - Bugfixes:
       - Fixed a `NullPointerException` (https://github.com/jline/jline3/issues/930) by updating a `jline` dependency. (PR #164). Thanks @koppor !
  * `0.10.1`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
     - Improvements:
       - Restored JDK 8 compatibility by using a multi-release JAR. The library now works on JDK 8+ while still providing JPMS module support for JDK 9+. This fixes #175. Thanks @LyingDoc !
     - Bugfixes:
-      - Fixed a `NullPointerException` (https://github.com/jline/jline3/issues/930) by updating a `jline` dependency. (PR #164). Thanks @koppor !
- * `0.10.1`:
+      - Fixed a `NullPointerException` (https://github.com/jline/jline3/issues/930) by updating a `jline` dependency (PR #164). Thanks @koppor !
+      - Fixed a problem with `jline` version mismatch (#169, PR #170). Thanks @hohwille @jan-vcapgemini !
+  * `0.10.1`:
      - Improvements:
         - Changed the JPMS module dependency `org.jline` to a more fine-grained module `org.jline.terminal` (#158, PR #159). Thanks @brett-smith !
         - Added a new builder method `setRenderer` to allow custom renderers (#157). Thanks @drothmaler !

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015--2024 Tongfei Chen and contributors
+Copyright (c) 2015--2026 Tongfei Chen and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # progressbar 
-[![Maven Central](https://img.shields.io/maven-central/v/me.tongfei/progressbar.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/me.tongfei/progressbar)
+[![Maven Central](https://maven-badges.sml.io/maven-central/me.tongfei/progressbar/badge.svg)](https://central.sonatype.com/artifact/me.tongfei/progressbar)
 
 A console progress bar for JVM with minimal runtime overhead.
 
@@ -29,7 +29,7 @@ Maven:
   <dependency>
       <groupId>me.tongfei</groupId>
       <artifactId>progressbar</artifactId>
-      <version>0.10.0</version>
+      <version>$VERSION</version>
   </dependency>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Depending on your build tool, add the following setting.
     compile 'me.tongfei:progressbar:$VERSION'
     ```
 
-The newest `$VERSION` is [![Maven Central](https://img.shields.io/maven-central/v/me.tongfei/progressbar.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/me.tongfei/progressbar).
+The newest `$VERSION` is [![Maven Central](https://maven-badges.sml.io/maven-central/me.tongfei/progressbar/badge.svg)](https://central.sonatype.com/artifact/me.tongfei/progressbar).
 
 #### Getting started
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: 'Progressbar'
 site_description: 'A terminal progress bar for Java/JVM'
 site_author: 'Tongfei Chen'
-copyright: 'Copyright &copy; 2015-2024 Tongfei Chen and contributors'
+copyright: 'Copyright &copy; 2015--2026 Tongfei Chen and contributors'
 
 theme:
   name: 'material'

--- a/pom.xml
+++ b/pom.xml
@@ -180,13 +180,9 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
 
     <build>
@@ -194,7 +190,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.13.0</version>
                 <executions>
                     <!-- Default compilation for Java 8 -->
                     <execution>
@@ -228,7 +224,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -240,7 +236,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -253,7 +249,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <doclint>all,-missing</doclint>
                     <detectJavaApiLink>false</detectJavaApiLink>
@@ -270,7 +266,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -282,20 +278,19 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.3</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.6.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.7.1</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -305,7 +300,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.5.2</version>
                 <configuration>
                     <useModulePath>false</useModulePath>  <!-- tests use classpath -->
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
 
     <groupId>me.tongfei</groupId>
     <artifactId>progressbar</artifactId>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
     <name>progressbar</name>
     <description>A terminal-based progress bar for JVM</description>
-    <url>http://github.com/ctongfei/progressbar</url>
+    <url>https://github.com/ctongfei/progressbar</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -20,7 +20,7 @@
     <licenses>
         <license>
             <name>MIT</name>
-            <url>http://opensource.org/licenses/MIT</url>
+            <url>https://opensource.org/licenses/MIT</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal</artifactId>
-            <version>3.26.2</version>
+            <version>3.29.0</version>
         </dependency>
 
         <dependency>
@@ -192,9 +192,42 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
+                <executions>
+                    <!-- Default compilation for Java 8 -->
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                        </configuration>
+                    </execution>
+                    <!-- Compile module-info.java for Java 9+ -->
+                    <execution>
+                        <id>compile-java9</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                            </compileSourceRoots>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
                 <configuration>
-                    <source>9</source>
-                    <target>9</target>
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,9 @@
             <id>koppor</id>
             <name>Oliver Kopp</name>
         </developer>
+        <developer>
+            <id>jan-vcapgemini</id>
+        </developer>
     </developers>
 
     <dependencies>
@@ -217,6 +220,10 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal</artifactId>
-            <version>3.26.2</version>
+            <version>3.29.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,0 @@
-module me.tongfei.progressbar {
-    requires org.jline.terminal;
-    exports me.tongfei.progressbar;
-}


### PR DESCRIPTION
 - Improvements:
      - Restored JDK 8 compatibility by using a multi-release JAR. The library now works on JDK 8+ while still providing JPMS module support for JDK 9+. This fixes #175. Thanks @LyingDoc !
 - Bugfixes:
      - Fixed a `NullPointerException` (https://github.com/jline/jline3/issues/930) by updating a `jline` dependency (PR #164). Thanks @koppor !
      - Fixed a problem with `jline` version mismatch (#169, PR #170). Thanks @hohwille @jan-vcapgemini !