### PR TITLE
fix: handle InterruptedException properly in ProgressBar.close() 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ site/
 # Dokka
 docs/dokka/
 docs/dokka-javadoc/
+
+docs-mine

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,11 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.21.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <executions>

--- a/src/main/java/me/tongfei/progressbar/ProgressBar.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressBar.java
@@ -189,7 +189,12 @@ public class ProgressBar implements AutoCloseable {
         progress.kill();
         try {
             Util.executor.schedule(action, 0, TimeUnit.NANOSECONDS).get();
-        } catch (InterruptedException | ExecutionException e) { /* NOOP */ }
+        } catch (InterruptedException e) {
+            // Restores the interrupt flag so callers are aware the thread was interrupted.
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            // Final render failed — non-critical, progress bar is already closing.
+        }
     }
 
     /**

--- a/src/test/java/me/tongfei/progressbar/OriginalBehaviorDemo.java
+++ b/src/test/java/me/tongfei/progressbar/OriginalBehaviorDemo.java
@@ -1,0 +1,63 @@
+package me.tongfei.progressbar;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Minimal demo to capture original progress bar behavior for assignment screenshots.
+ * Runs quickly and cleanly — does NOT modify the original test files.
+ */
+class OriginalBehaviorDemo {
+
+    @Test
+    void demoBasicProgressBar() throws InterruptedException {
+        System.out.println("\n=== Demo 1: Basic Unicode Block Bar ===");
+        try (ProgressBar pb = new ProgressBarBuilder()
+                .setTaskName("Processing")
+                .setInitialMax(10)
+                .setStyle(ProgressBarStyle.COLORFUL_UNICODE_BLOCK)
+                .setUpdateIntervalMillis(200)
+                .build()) {
+            for (int i = 0; i < 10; i++) {
+                Thread.sleep(300);
+                pb.step();
+            }
+        }
+        System.out.println();
+    }
+
+    @Test
+    void demoSpeedBar() throws InterruptedException {
+        System.out.println("\n=== Demo 2: Bar with Speed Display ===");
+        try (ProgressBar pb = new ProgressBarBuilder()
+                .setTaskName("Downloading")
+                .setInitialMax(10)
+                .setStyle(ProgressBarStyle.ASCII)
+                .setUnit("MB", 1)
+                .showSpeed()
+                .setUpdateIntervalMillis(200)
+                .build()) {
+            for (int i = 0; i < 10; i++) {
+                Thread.sleep(300);
+                pb.step();
+            }
+        }
+        System.out.println();
+    }
+
+    @Test
+    void demoIndefiniteBar() throws InterruptedException {
+        System.out.println("\n=== Demo 3: Indefinite (Unknown Max) Bar ===");
+        try (ProgressBar pb = new ProgressBarBuilder()
+                .setTaskName("Scanning")
+                .setInitialMax(-1)    // -1 = indefinite, max is unknown
+                .setStyle(ProgressBarStyle.COLORFUL_UNICODE_BAR)
+                .setUpdateIntervalMillis(200)
+                .build()) {
+            for (int i = 0; i < 10; i++) {
+                Thread.sleep(300);
+                pb.step();
+            }
+        }
+        System.out.println();
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                     
The `close()` method in `ProgressBar` was silently swallowing `InterruptedException` and `ExecutionException` with an empty catch block (`/* NOOP */`). This was flagged by PMD as an `EmptyCatchBlock` violation (Error Prone category, priority 3)
                                                                                      
## Problem                                                                                                                     
Catching `InterruptedException` without restoring the interrupt flag discards the thread's interrupted state silently. Any code up the call stack that checks `Thread.isInterrupted()` will never know the interruption happened, which can cause subtle and hard-to-debug issues in multi-threaded environments.                                                                                                
                                                                                                                                   
## Changes                                                                                                                     
- Split the combined `catch` into two separate handlers                                                                        
- `InterruptedException` → calls `Thread.currentThread().interrupt()` to restore the interrupt flag per Java best practice                                                                         
- `ExecutionException` → retained as a no-op but with an explanatory comment, since a failed final render is non-critical during shutdown                                                         
                                                                                                                                   
## Testing
All existing tests pass. Behaviour is functionally unchanged. 