### PR TITLE
Refactor field access

### DIFF
--- a/src/main/java/me/tongfei/progressbar/DefaultProgressBarRenderer.java
+++ b/src/main/java/me/tongfei/progressbar/DefaultProgressBarRenderer.java
@@ -69,14 +69,14 @@ public class DefaultProgressBarRenderer implements ProgressBarRenderer {
 
     protected String percentage(ProgressState progress) {
         String res;
-        if (progress.max <= 0 || progress.indefinite) res = "? %";
-        else res = String.valueOf((int) Math.floor(100.0 * progress.current / progress.max)) + "%";
+        if (progress.getMax() <= 0 || progress.isIndefinite()) res = "? %";
+        else res = String.valueOf((int) Math.floor(100.0 * progress.getCurrent() / progress.getMax())) + "%";
         return Util.repeat(' ', 4 - res.length()) + res;
     }
 
     protected String ratio(ProgressState progress) {
-        String m = progress.indefinite ? "?" : String.valueOf(progress.max / unitSize);
-        String c = String.valueOf(progress.current / unitSize);
+        String m = progress.isIndefinite() ? "?" : String.valueOf(progress.getMax() / unitSize);
+        String c = String.valueOf(progress.getCurrent() / unitSize);
         return Util.repeat(' ', m.length() - c.length()) + c + "/" + m + unitName;
     }
 
@@ -102,7 +102,7 @@ public class DefaultProgressBarRenderer implements ProgressBarRenderer {
 
         if (elapsedSeconds == 0)
             return "?" + unitName + suffix;
-        double speed = (double) (progress.current - progress.start) / elapsedInUnit;
+        double speed = (double) (progress.getCurrent() - progress.getStart()) / elapsedInUnit;
         double speedWithUnit = speed / unitSize;
         return speedFormat.format(speedWithUnit) + unitName + suffix;
     }
@@ -128,7 +128,7 @@ public class DefaultProgressBarRenderer implements ProgressBarRenderer {
                 + Util.formatDuration(progress.getTotalElapsed())
                 + (isEtaShown ? " / " + etaString(progress) : "")
                 + ") "
-                + speedString + progress.extraMessage;
+                + speedString + progress.getExtraMessage();
         int suffixLength = getStringDisplayLength(suffix);
         // trim excessive suffix
         if (suffixLength > maxSuffixLength) {
@@ -142,8 +142,8 @@ public class DefaultProgressBarRenderer implements ProgressBarRenderer {
         sb.append(prefix);
 
         // case of indefinite progress bars
-        if (progress.indefinite) {
-            int pos = (int)(progress.current % length);
+        if (progress.isIndefinite()) {
+            int pos = (int)(progress.getCurrent() % length);
             sb.append(Util.repeat(style.space, pos));
             sb.append(style.block);
             sb.append(Util.repeat(style.space, length - pos - 1));
@@ -151,7 +151,7 @@ public class DefaultProgressBarRenderer implements ProgressBarRenderer {
         // case of definite progress bars
         else {
             sb.append(Util.repeat(style.block, progressIntegralPart(progress, length)));
-            if (progress.current < progress.max) {
+            if (progress.getCurrent() < progress.getMax()) {
                 int fraction = progressFractionalPart(progress, length);
                 if (fraction != 0) {
                     sb.append(style.fractionSymbols.charAt(fraction));

--- a/src/main/java/me/tongfei/progressbar/ProgressUpdateAction.java
+++ b/src/main/java/me/tongfei/progressbar/ProgressUpdateAction.java
@@ -25,12 +25,12 @@ class ProgressUpdateAction implements Runnable {
         this.consumer = consumer;
         this.continuousUpdate = continuousUpdate;
         this.clearDisplayOnFinish = clearDisplayOnFinish;
-        this.last = progress.start;
+        this.last = progress.getStart();
         this.first = true;
     }
 
     void refresh() {
-        if (continuousUpdate || (progress.current > last))
+        if (continuousUpdate || (progress.getCurrent() > last))
             forceRefresh();
         // else do nothing: only print when actual progress is made (#91).
     }
@@ -38,7 +38,7 @@ class ProgressUpdateAction implements Runnable {
     public void forceRefresh() {
         String rendered = renderer.render(progress, consumer.getMaxRenderedLength());
         consumer.accept(rendered);
-        last = progress.current;
+        last = progress.getCurrent();
     }
 
     public void run() {
@@ -47,8 +47,8 @@ class ProgressUpdateAction implements Runnable {
             first = false;
         }
         else {
-            if (!progress.paused) refresh();
-            if (!progress.alive) {
+            if (!progress.isPaused()) refresh();
+            if (!progress.isAlive()) {
                 forceRefresh();
                 if (clearDisplayOnFinish) consumer.clear();
                 consumer.close();


### PR DESCRIPTION
## Summary                                                                                                                                                 
Replaced all direct package-private field accesses to `ProgressState` with their existing public synchronized getter methods in `DefaultProgressBarRenderer` and `ProgressUpdateAction`.                                                                                                   
                                                                                                                                                               
## Problem                                                                                                                                                 
Both classes were bypassing `ProgressState`'s getter methods and reading its internal fields (`max`, `current`, `indefinite`, `start`, `extraMessage`, `paused`, `alive`) directly. This is an Inappropriate Intimacy code smell. The classes are coupled to the exact internal field layout of `ProgressState`.                                                                                                                           
                                                                                                                                                               
This also has a thread-safety implication: the getter methods are `synchronized`, but direct field reads are not, which could lead to inconsistent reads in multi-threaded scenarios (e.g., parallel stream progress tracking).                                                                                                                                        
                                                                                                                                                               
## Changes
- `DefaultProgressBarRenderer`: replaced 11 direct field accesses across `percentage()`, `ratio()`, `speed()`, and `render()` with `getMax()`, `getCurrent()`, `isIndefinite()`, `getStart()`, `getExtraMessage()`
- `ProgressUpdateAction`: replaced 4 direct field accesses across the constructor, `refresh()`, `forceRefresh()`, and `run()` with `getStart()`, `getCurrent()`, `isPaused()`, `isAlive()`
              
## Testing
All existing tests pass. Functionality is unchanged.